### PR TITLE
hotfix: ios archive error vs Xcode10+

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -34,6 +34,19 @@ target 'taroDemo' do
 
   pod 'react-native-webview', :path => '../node_modules/react-native-webview'
 
+  # fix archive error vs Xcode10+
+  post_install do |installer|
+    installer.pods_project.targets.each do |target|
+      if target.name == "React"
+        target.remove_from_project
+      end
+
+      if target.name == "yoga"
+        target.remove_from_project
+      end
+    end
+  end
+
   target 'taroDemoTests' do
     inherit! :search_paths
   end


### PR DESCRIPTION
解决 ios archive 时，报错问题，报错信息如下：

Multiple commands produce '/Users/tu/Library/Developer/Xcode/DerivedData/Tituk-fndmfujccqhdareyswrxhslqzyvn/Build/Intermediates.noindex/ArchiveIntermediates/Tituk/IntermediateBuildFilesPath/UninstalledProducts/iphoneos/libyoga.a':

Target 'yoga' has a command with output '/Users/tu/Library/Developer/Xcode/DerivedData/Tituk-fndmfujccqhdareyswrxhslqzyvn/Build/Intermediates.noindex/ArchiveIntermediates/Tituk/IntermediateBuildFilesPath/UninstalledProducts/iphoneos/libyoga.a'
Target 'yoga' has a command with output '/Users/tu/Library/Developer/Xcode/DerivedData/Tituk-fndmfujccqhdareyswrxhslqzyvn/Build/Intermediates.noindex/ArchiveIntermediates/Tituk/IntermediateBuildFilesPath/UninstalledProducts/iphoneos/libyoga.a'

解决方案：
更新 podfile 内容：
```
  post_install do |installer|
    installer.pods_project.targets.each do |target|
      if target.name == "React"
        target.remove_from_project
      end

      if target.name == "yoga"
        target.remove_from_project
      end
    end
  end
```
执行 pod install
xcode workspace 选择 Legacy Build System
archive 操作成功